### PR TITLE
fix: anchor buildspec cd to CODEBUILD_SRC_DIR for iac_working_directory

### DIFF
--- a/modules/core/buildspecs/deploy.yml
+++ b/modules/core/buildspecs/deploy.yml
@@ -34,7 +34,7 @@ phases:
         set -euo pipefail
         if [ "${IAC_WORKING_DIR}" != "." ]; then
           echo "Changing to IaC directory: ${IAC_WORKING_DIR}"
-          cd "${IAC_WORKING_DIR}"
+          cd "${CODEBUILD_SRC_DIR}/${IAC_WORKING_DIR}"
         fi
 
         echo "Assuming cross-account role: $TARGET_ROLE"

--- a/modules/core/buildspecs/plan.yml
+++ b/modules/core/buildspecs/plan.yml
@@ -36,7 +36,7 @@ phases:
         set -euo pipefail
         if [ "${IAC_WORKING_DIR}" != "." ]; then
           echo "Changing to IaC directory: ${IAC_WORKING_DIR}"
-          cd "${IAC_WORKING_DIR}"
+          cd "${CODEBUILD_SRC_DIR}/${IAC_WORKING_DIR}"
         fi
         echo "Initializing Terraform with S3 backend..."
         terraform init \
@@ -53,7 +53,7 @@ phases:
       - |
         set -euo pipefail
         if [ "${IAC_WORKING_DIR}" != "." ]; then
-          cd "${IAC_WORKING_DIR}"
+          cd "${CODEBUILD_SRC_DIR}/${IAC_WORKING_DIR}"
         fi
         echo "Running terraform plan..."
         terraform plan -out=tfplan -input=false

--- a/modules/default-dev-destroy/buildspecs/destroy.yml
+++ b/modules/default-dev-destroy/buildspecs/destroy.yml
@@ -34,7 +34,7 @@ phases:
         set -euo pipefail
         if [ "${IAC_WORKING_DIR}" != "." ]; then
           echo "Changing to IaC directory: ${IAC_WORKING_DIR}"
-          cd "${IAC_WORKING_DIR}"
+          cd "${CODEBUILD_SRC_DIR}/${IAC_WORKING_DIR}"
         fi
 
         echo "Assuming cross-account role: $TARGET_ROLE"


### PR DESCRIPTION
## Summary
- Fixes Plan stage BUILD phase failure when `iac_working_directory` is set to a subdirectory (e.g., `terraform`)
- In CodeBuild, working directory persists across buildspec phases. The `pre_build` phase in `plan.yml` cd's into `IAC_WORKING_DIR` for `terraform init`, then the `build` phase inherits that CWD and the relative `cd` resolves to a non-existent nested path (`terraform/terraform/`)
- All `cd "${IAC_WORKING_DIR}"` commands in buildspecs now anchor to `$CODEBUILD_SRC_DIR` for deterministic behavior regardless of inherited working directory state
- Affected files: `plan.yml`, `deploy.yml`, `destroy.yml`

Fixes #4

## Test plan
- [ ] Re-run the `chatbot-teams` pipeline with `iac_working_directory = "terraform"` and verify Plan stage completes
- [ ] Verify Deploy stage also succeeds with the anchored cd path
- [ ] Confirm pipelines with default `iac_working_directory = "." ` are unaffected (cd is skipped)

Generated with [Claude Code](https://claude.com/claude-code)